### PR TITLE
Rest the IFS value immediately after use when switching to a working directory

### DIFF
--- a/wd/wd.sh
+++ b/wd/wd.sh
@@ -181,11 +181,12 @@ function wdretr() {
   _ifs_tmp=$IFS
   IFS=$'\n'
   slots=( $(cat $(_wd_env_scheme_filename)) )
+  IFS=$_ifs_tmp
+  
   if [ ! ${slots[$slot]} == '.' ]
   then
     cd ${slots[$slot]}
   fi
-  IFS=$_ifs_tmp
 }
 
 function wdl() {


### PR DESCRIPTION
This fixes a problem when the "wd" directory has a .rvmrc file in it. When working-directory changes the IFS, it was not previously being set back to the original value until after the directory change - which is when rvm was trying to use the default field separator value.
